### PR TITLE
Fix automations: update the index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/5.0.0/documentation/revenuecat"/>
+    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/5.3.1/documentation/revenuecat"/>
 </head>
 <body>
 </body>


### PR DESCRIPTION
Update the index.html file to point to the latest version. I think that should fix the automation from now on, though I haven't checked yet. 

In the meantime, it should fix the link itself to point to the current latest at least, and that in turn fixes the inherited symbols since they're not correctly generated in the 5.0.0 version