### PR TITLE
Update index.html to point to latest

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/4.43.2/documentation/revenuecat"/>
+    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/5.6.0/documentation/revenuecat"/>
 </head>
 <body>
 </body>


### PR DESCRIPTION
Not entirely sure why this was pointing to v4, I'm guessing that after a v4 hotfix the automation failed to grep when going for v5. We should dig in, but in the meantime, this points the docs root to 5.6.0